### PR TITLE
Simplify the release name

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -49,7 +49,7 @@ jobs:
         publish_dir: ./public
     - name: Set Tag
       id: current-datetime
-      run: echo "CURRENT_DATETIME=$(date +'%Y-%m-%d-%H_%M_%S%z')" >> "$GITHUB_OUTPUT"
+      run: echo "CURRENT_DATETIME=$(date +'%Y%m%d%H%M')" >> "$GITHUB_OUTPUT"
     - name: Build Release
       shell: bash
       run: |


### PR DESCRIPTION
Change the release name to YYYYMMDDhhmm format from the date command line.